### PR TITLE
[PYT-153] Update <p> tags in Notes/Warnings

### DIFF
--- a/pytorch_sphinx_theme/static/css/theme.css
+++ b/pytorch_sphinx_theme/static/css/theme.css
@@ -9356,8 +9356,8 @@ article.pytorch-article .warning .first:before {
   padding-left: 10px;
   padding-right: 15px;
 }
-article.pytorch-article .note p,
-article.pytorch-article .warning p {
+article.pytorch-article .note p:nth-child(n+2),
+article.pytorch-article .warning p:nth-child(n+2) {
   padding: 0 2rem;
   font-size: 1.125rem;
   color: #262626;
@@ -9395,7 +9395,7 @@ article.pytorch-article div.last .highlight {
 }
 article.pytorch-article p.last {
   margin-bottom: 0;
-  padding-bottom: 1.125rem;
+  padding-bottom: 1.125rem !important;
 }
 
 .sphx-glr-thumbcontainer {

--- a/scss/_sphinx_base.scss
+++ b/scss/_sphinx_base.scss
@@ -128,7 +128,7 @@ article.pytorch-article {
         padding-right: 15px;
       }
     }
-    p {
+    p:nth-child(n+2) {
       padding: 0 rem(32px);
       font-size: rem(18px);
       color: $not_quite_black;
@@ -174,7 +174,7 @@ article.pytorch-article {
 
   p.last {
     margin-bottom: 0;
-    padding-bottom: rem(18px);
+    padding-bottom: rem(18px) !important;
   }
 }
 


### PR DESCRIPTION
The `<p>` margins are larger than the `pre` margins, so when a Note has both it looks a little off: [http://localhost:1919/tensor_attributes.html](http://localhost:1919/tensor_attributes.html). The `<p>` margins are larger so that the text lines up with the Note title.