### PR TITLE
[PYT-160] Don't show top-level menu (article name) item in right menu

### DIFF
--- a/js/highlight-navigation.js
+++ b/js/highlight-navigation.js
@@ -10,16 +10,9 @@ window.highlightNavigation = {
   sectionIdTonavigationLink: {},
 
   bind: function() {
-    // Sphinx automatically tags the first menu item with just a "#" href, which brings
-    // you to the top of the page. We want to instead give this an href of the first content
-    // section so that it highlights like every other menu item.
-    var $firstNavItem = $(".pytorch-right-menu li a:first");
-
-    if ($firstNavItem.attr("href") === "#") {
-      var firstSectionId = $(".pytorch-article .section")
-        .first()
-        .attr("id");
-      $firstNavItem.attr("href", "#" + firstSectionId);
+    // Don't show the "Shortcuts" text unless there are menu items
+    if (highlightNavigation.navigationListItems.length > 1) {
+      $(".pytorch-shortcuts-wrapper").show();
     }
 
     highlightNavigation.sections.each(function() {
@@ -66,8 +59,11 @@ window.highlightNavigation = {
         if (!$navigationListItem.hasClass("active")) {
           highlightNavigation.navigationListItems.removeClass("active");
           $(".pytorch-right-menu-active-dot").remove();
-          $navigationListItem.addClass("active");
-          $navigationListItem.prepend("<div class=\"pytorch-right-menu-active-dot\"></div>");
+
+          if ($navigationLink.is(":visible")) {
+            $navigationListItem.addClass("active");
+            $navigationListItem.prepend("<div class=\"pytorch-right-menu-active-dot\"></div>");
+          }
         }
 
         return false;

--- a/pytorch_sphinx_theme/static/css/theme.css
+++ b/pytorch_sphinx_theme/static/css/theme.css
@@ -9898,26 +9898,26 @@ article.pytorch-article p.last {
 .pytorch-right-menu ul ul {
   padding-left: 0;
 }
-.pytorch-right-menu ul ul li a {
-  text-indent: 10px;
-}
 .pytorch-right-menu ul ul li {
-  text-indent: 5px;
+  text-indent: 0px;
 }
 .pytorch-right-menu ul ul li li {
+  text-indent: 5px;
+}
+.pytorch-right-menu ul ul li li a {
   text-indent: 15px;
 }
 .pytorch-right-menu ul ul li li li {
-  text-indent: 25px;
+  text-indent: 10px;
 }
 .pytorch-right-menu ul ul li li li li {
-  text-indent: 35px;
+  text-indent: 15px;
 }
 .pytorch-right-menu ul ul li li li li li {
-  text-indent: 45px;
+  text-indent: 20px;
 }
 .pytorch-right-menu ul ul li li li li li li {
-  text-indent: 55px;
+  text-indent: 25px;
 }
 .pytorch-right-menu li ul {
   display: block;
@@ -9930,6 +9930,9 @@ article.pytorch-article p.last {
 .pytorch-right-menu .pytorch-side-scroll > ul {
   padding-left: 25px;
 }
+.pytorch-right-menu .pytorch-side-scroll > ul > li > a {
+  display: none;
+}
 .pytorch-right-menu .pytorch-side-scroll ul li {
   position: relative;
 }
@@ -9939,24 +9942,24 @@ article.pytorch-article p.last {
   height: 1px;
   display: inline-block;
   position: absolute;
-  left: 0;
+  left: 5px;
   top: 13px;
-  width: 5px;
+  width: 0;
 }
 .pytorch-right-menu .pytorch-side-scroll ul ul li li:before {
-  width: 15px;
+  width: 5px;
 }
 .pytorch-right-menu .pytorch-side-scroll ul ul li li li:before {
-  width: 25px;
+  width: 10px;
 }
 .pytorch-right-menu .pytorch-side-scroll ul ul li li li li:before {
-  width: 35px;
+  width: 15px;
 }
 .pytorch-right-menu .pytorch-side-scroll ul ul li li li li li:before {
-  width: 45px;
+  width: 20px;
 }
 .pytorch-right-menu .pytorch-side-scroll ul ul li li li li li li:before {
-  width: 55px;
+  width: 25px;
 }
 .pytorch-right-menu .pytorch-side-scroll ul ul li.active:before {
   background-color: #e44c2c;
@@ -10028,6 +10031,7 @@ article.pytorch-article p.last {
 }
 
 .pytorch-shortcuts-wrapper {
+  display: none;
   position: absolute;
   left: 810px;
 }

--- a/pytorch_sphinx_theme/static/js/theme.js
+++ b/pytorch_sphinx_theme/static/js/theme.js
@@ -11,16 +11,9 @@ window.highlightNavigation = {
   sectionIdTonavigationLink: {},
 
   bind: function() {
-    // Sphinx automatically tags the first menu item with just a "#" href, which brings
-    // you to the top of the page. We want to instead give this an href of the first content
-    // section so that it highlights like every other menu item.
-    var $firstNavItem = $(".pytorch-right-menu li a:first");
-
-    if ($firstNavItem.attr("href") === "#") {
-      var firstSectionId = $(".pytorch-article .section")
-        .first()
-        .attr("id");
-      $firstNavItem.attr("href", "#" + firstSectionId);
+    // Don't show the "Shortcuts" text unless there are menu items
+    if (highlightNavigation.navigationListItems.length > 1) {
+      $(".pytorch-shortcuts-wrapper").show();
     }
 
     highlightNavigation.sections.each(function() {
@@ -67,8 +60,11 @@ window.highlightNavigation = {
         if (!$navigationListItem.hasClass("active")) {
           highlightNavigation.navigationListItems.removeClass("active");
           $(".pytorch-right-menu-active-dot").remove();
-          $navigationListItem.addClass("active");
-          $navigationListItem.prepend("<div class=\"pytorch-right-menu-active-dot\"></div>");
+
+          if ($navigationLink.is(":visible")) {
+            $navigationListItem.addClass("active");
+            $navigationListItem.prepend("<div class=\"pytorch-right-menu-active-dot\"></div>");
+          }
         }
 
         return false;

--- a/scss/_sphinx_layout.scss
+++ b/scss/_sphinx_layout.scss
@@ -352,22 +352,21 @@
   ul ul {
     padding-left: 0;
 
-    li a {
-      text-indent: 10px;
-    }
-
     li {
-      text-indent: 5px;
+      text-indent: 0px;
       li {
-        text-indent: 15px;
+        text-indent: 5px;
+        a {
+          text-indent: 15px;
+        }
         li {
-          text-indent: 25px;
+          text-indent: 10px;
           li {
-            text-indent: 35px;
+            text-indent: 15px;
             li {
-              text-indent: 45px;
+              text-indent: 20px;
               li {
-                text-indent: 55px;
+                text-indent: 25px;
               }
             }
           }
@@ -387,6 +386,10 @@
 
   > ul {
     padding-left: 25px;
+    // Hide the first level (title) of the article
+    > li > a {
+      display: none;
+    }
   }
 
   ul li {
@@ -401,30 +404,30 @@
         height: 1px;
         display: inline-block;
         position: absolute;
-        left: 0;
+        left: 5px;
         top: 13px;
-        width: 5px;
+        width: 0;
       }
 
       li {
         &:before {
-          width: 15px;
+          width: 5px;
         }
         li {
           &:before {
-            width: 25px;
+            width: 10px;
           }
           li {
             &:before {
-              width: 35px;
+              width: 15px;
             }
             li {
               &:before {
-                width: 45px;
+                width: 20px;
               }
               li {
                 &:before {
-                  width: 55px;
+                  width: 25px;
                 }
               }
             }
@@ -506,6 +509,7 @@
 }
 
 .pytorch-shortcuts-wrapper {
+  display: none;
   position: absolute;
   left: 60px + 675px + 50px + 25px;
 }


### PR DESCRIPTION
- Only show the article sub-sections in the right menu
- If there are no sub-sections don't show the "Shortcuts" text