### PR TITLE
[PYT-168] Restructure page layout to accommodate laptop screen sizes

### DIFF
--- a/js/side-menus.js
+++ b/js/side-menus.js
@@ -1,18 +1,13 @@
 window.sideMenus = {
-  rightMenuInitialTop: parseInt($(".pytorch-right-menu").css("top"), 10),
+  rightMenuInitialTop: $(".pytorch-article h1:first").offset().top,
 
   bind: function() {
+    // Start the Shortcuts menu at the article's H1 position
+    $(".pytorch-right-menu").css({top: sideMenus.rightMenuInitialTop});
+
     $(window).on('load resize scroll', function(e) {
       sideMenus.handleLeftMenu();
       sideMenus.handleRightMenu();
-    });
-
-    $(window).on("load resize", function() {
-      var leftMenuWidth = $(".pytorch-left-menu").width();
-      var contentRightLeftOffset = $(".pytorch-content-right").offset().left;
-      var pageLevelPaddingLeft = parseInt($(".pytorch-page-level-bar").css("padding-left"), 10);
-      $(".pytorch-right-menu").css({left: contentRightLeftOffset});
-      $(".pytorch-shortcuts-wrapper").css({left: contentRightLeftOffset - leftMenuWidth - pageLevelPaddingLeft});
     });
   },
 
@@ -54,9 +49,9 @@ window.sideMenus = {
     //          of the footer minus padding
 
     if ($rightMenu.hasClass("fixed-to-bottom") && topOfFooterRelativeToWindow >= windowHeight) {
-      $rightMenu.removeClass("fixed-to-bottom").css({top: stoppingPoint, left: ""});
+      $rightMenu.removeClass("fixed-to-bottom").css({top: stoppingPoint});
     } else if (bottom >= -PADDING_BETWEEN_MENU_AND_FOOTER + footerTop) {
-      $rightMenu.addClass("fixed-to-bottom").css({top: "auto", left: 0});
+      $rightMenu.addClass("fixed-to-bottom").css({top: "auto"});
     } else {
       var top = scrollPos >= (initialTop - stoppingPoint)
                   ? stoppingPoint

--- a/pytorch_sphinx_theme/static/css/theme.css
+++ b/pytorch_sphinx_theme/static/css/theme.css
@@ -9224,6 +9224,17 @@ article.pytorch-article img {
   width: 100%;
 }
 
+@media screen and (min-width: 768px) {
+  html {
+    font-size: 14px;
+  }
+}
+@media screen and (min-width: 1600px) {
+  html {
+    font-size: 16px;
+  }
+}
+
 body {
   background: #ffffff;
   height: 100%;
@@ -9672,43 +9683,62 @@ a[rel~="prev"], a[rel~="next"] {
 .pytorch-content-wrap {
   *zoom: 1;
 }
-@media screen and (min-width: 1100px) {
+@media screen and (min-width: 1101px) {
   .pytorch-content-wrap {
+    left: 27%;
+    padding-top: 160px;
+    width: 71%;
+  }
+}
+@media screen and (min-width: 1600px) {
+  .pytorch-content-wrap {
+    left: auto;
     margin-left: 480px;
     padding-top: 220px;
+    width: auto;
   }
 }
 
 .pytorch-content {
   background: #ffffff;
   width: 100%;
-  max-width: 675px;
+  max-width: 700px;
   position: relative;
 }
 
 .pytorch-content-left {
   width: 100%;
 }
-@media screen and (min-width: 1100px) {
+@media screen and (min-width: 1101px) {
   .pytorch-content-left {
-    width: 675px;
+    width: 75%;
+  }
+}
+@media screen and (min-width: 1600px) {
+  .pytorch-content-left {
+    width: 700px;
   }
 }
 
 .pytorch-content-right {
   display: none;
+  position: relative;
 }
-@media screen and (min-width: 1100px) {
+@media screen and (min-width: 1101px) {
   .pytorch-content-right {
     display: block;
+    left: 2%;
+    width: 24%;
+  }
+}
+@media screen and (min-width: 1600px) {
+  .pytorch-content-right {
     width: 350px;
-    position: relative;
-    left: 50px;
+    left: 0;
   }
 }
 
 .pytorch-side-scroll {
-  width: 410px;
   position: relative;
   overflow-x: hidden;
   overflow-y: scroll;
@@ -9716,23 +9746,18 @@ a[rel~="prev"], a[rel~="next"] {
 }
 
 .pytorch-menu-vertical {
-  padding-bottom: 90px;
-  padding-right: 1.875rem;
+  padding: 4.375rem 1.875rem 5.625rem 0;
 }
-
-.pytorch-left-menu-search {
-  margin: 2.5rem 0 3.75rem 0;
-  padding-left: 1.875rem;
+@media screen and (min-width: 1101px) {
+  .pytorch-menu-vertical {
+    padding-top: 0;
+    padding-right: 15%;
+  }
 }
-
-.pytorch-left-menu-search input[type=text] {
-  border-radius: 0;
-  padding: 0.5rem 0.75rem;
-  border-color: #e44c2c;
-  color: #e44c2c;
-  border-style: solid;
-  font-size: 1rem;
-  width: 100%;
+@media screen and (min-width: 1600px) {
+  .pytorch-menu-vertical {
+    padding-right: 1.875rem;
+  }
 }
 
 .pytorch-left-menu {
@@ -9765,15 +9790,7 @@ a[rel~="prev"], a[rel~="next"] {
   top: 15px;
   z-index: 100;
 }
-.pytorch-left-menu a.close-table-of-contents {
-  display: block;
-}
-@media screen and (min-width: 1100px) {
-  .pytorch-left-menu a.close-table-of-contents {
-    display: none;
-  }
-}
-@media screen and (min-width: 1100px) {
+@media screen and (min-width: 1101px) {
   .pytorch-left-menu {
     background: #f3f4f7;
     bottom: 0;
@@ -9783,13 +9800,21 @@ a[rel~="prev"], a[rel~="next"] {
     overflow-x: hidden;
     overflow-y: hidden;
     padding-bottom: 110px;
-    padding: 0 3.75rem 0 1.875rem;
+    padding: 0 1.875rem 0 0;
     position: fixed;
     top: 90px;
-    width: 420px;
+    min-width: 280px;
+    width: 25%;
     z-index: 200;
   }
 }
+@media screen and (min-width: 1600px) {
+  .pytorch-left-menu {
+    padding: 0 3.75rem 0 1.875rem;
+    width: 420px;
+  }
+}
+
 .pytorch-left-menu p.caption {
   color: #262626;
   display: block;
@@ -9800,7 +9825,56 @@ a[rel~="prev"], a[rel~="next"] {
   padding: 0;
   text-transform: none;
   white-space: nowrap;
-  padding-left: 1.875rem;
+}
+@media screen and (min-width: 1101px) {
+  .pytorch-left-menu p.caption {
+    padding-left: 1.875rem;
+  }
+}
+
+.pytorch-left-menu a.close-table-of-contents {
+  display: block;
+}
+@media screen and (min-width: 1100px) {
+  .pytorch-left-menu a.close-table-of-contents {
+    display: none;
+  }
+}
+
+.pytorch-left-menu-search {
+  margin-bottom: 2.5rem;
+}
+@media screen and (min-width: 1101px) {
+  .pytorch-left-menu-search {
+    margin: 1.25rem 0 1.875rem 0;
+    padding-left: 1.875rem;
+  }
+}
+@media screen and (min-width: 1600px) {
+  .pytorch-left-menu-search {
+    margin: 2.5rem 0 3.75rem 0;
+  }
+}
+
+.pytorch-left-menu-search input[type=text] {
+  border-radius: 0;
+  padding: 0.5rem 0.75rem;
+  border-color: #e44c2c;
+  color: #e44c2c;
+  border-style: solid;
+  font-size: 1rem;
+  width: 100%;
+}
+
+@media screen and (min-width: 1101px) {
+  .pytorch-left-menu .pytorch-side-scroll {
+    width: 120%;
+  }
+}
+@media screen and (min-width: 1600px) {
+  .pytorch-left-menu .pytorch-side-scroll {
+    width: 410px;
+  }
 }
 
 .pytorch-right-menu {
@@ -9808,16 +9882,28 @@ a[rel~="prev"], a[rel~="next"] {
   overflow-x: hidden;
   overflow-y: hidden;
   position: fixed;
-  top: 315px;
-  width: 420px;
+  top: auto;
   z-index: 200;
   bottom: 0;
+}
+@media screen and (min-width: 1101px) {
+  .pytorch-right-menu {
+    left: 81.5%;
+    width: 17%;
+  }
+}
+@media screen and (min-width: 1600px) {
+  .pytorch-right-menu {
+    left: 1200px;
+    width: 380px;
+  }
 }
 .pytorch-right-menu.fixed-to-bottom {
   top: auto;
   bottom: 20px;
   position: absolute;
   left: 0;
+  width: 100%;
 }
 
 .pytorch-left-menu ul,
@@ -9948,7 +10034,12 @@ a[rel~="prev"], a[rel~="next"] {
 }
 
 .pytorch-left-menu ul {
-  padding-left: 1.875rem;
+  padding-left: 0;
+}
+@media screen and (min-width: 1101px) {
+  .pytorch-left-menu ul {
+    padding-left: 1.875rem;
+  }
 }
 
 .pytorch-right-menu a:link,
@@ -9963,36 +10054,48 @@ a[rel~="prev"], a[rel~="next"] {
   padding-left: 0;
 }
 .pytorch-right-menu ul ul li {
-  text-indent: 0px;
+  padding-left: 0px;
 }
 .pytorch-right-menu ul ul li li {
-  text-indent: 5px;
+  padding-left: 5px;
 }
-.pytorch-right-menu ul ul li li a {
-  text-indent: 15px;
+.pytorch-right-menu ul ul li li a:link,
+.pytorch-right-menu ul ul li li a:visited,
+.pytorch-right-menu ul ul li li a:hover {
+  padding-left: 5px;
 }
 .pytorch-right-menu ul ul li li li {
-  text-indent: 10px;
+  padding-left: 10px;
 }
 .pytorch-right-menu ul ul li li li li {
-  text-indent: 15px;
+  padding-left: 15px;
 }
 .pytorch-right-menu ul ul li li li li li {
-  text-indent: 20px;
+  padding-left: 20px;
 }
 .pytorch-right-menu ul ul li li li li li li {
-  text-indent: 25px;
+  padding-left: 25px;
 }
 .pytorch-right-menu li ul {
   display: block;
 }
 
 .pytorch-right-menu .pytorch-side-scroll {
-  width: 440px;
   padding-top: 20px;
 }
+@media screen and (min-width: 1101px) {
+  .pytorch-right-menu .pytorch-side-scroll {
+    width: 120%;
+  }
+}
+@media screen and (min-width: 1600px) {
+  .pytorch-right-menu .pytorch-side-scroll {
+    width: 440px;
+  }
+}
 .pytorch-right-menu .pytorch-side-scroll > ul {
-  padding-left: 25px;
+  padding-left: 10%;
+  padding-right: 10%;
 }
 .pytorch-right-menu .pytorch-side-scroll > ul > li > a {
   display: none;
@@ -10006,9 +10109,14 @@ a[rel~="prev"], a[rel~="next"] {
   height: 1px;
   display: inline-block;
   position: absolute;
-  left: 5px;
-  top: 13px;
+  left: 0;
+  top: 10px;
   width: 0;
+}
+@media screen and (min-width: 1600px) {
+  .pytorch-right-menu .pytorch-side-scroll ul ul li:before {
+    top: 13px;
+  }
 }
 .pytorch-right-menu .pytorch-side-scroll ul ul li li:before {
   width: 5px;
@@ -10059,7 +10167,13 @@ a[rel~="prev"], a[rel~="next"] {
   padding-right: 1.875rem;
   padding-left: 1.875rem;
 }
-@media screen and (min-width: 1100px) {
+@media screen and (min-width: 1101px) {
+  .header-holder .container {
+    padding-right: 1.875rem;
+    padding-left: 1.875rem;
+  }
+}
+@media screen and (min-width: 1600px) {
   .header-holder .container {
     padding-right: 3.75rem;
     padding-left: 3.75rem;
@@ -10069,25 +10183,50 @@ a[rel~="prev"], a[rel~="next"] {
 .header-holder .main-menu {
   justify-content: unset;
   position: relative;
-  left: 380px;
+}
+@media screen and (min-width: 1101px) {
+  .header-holder .main-menu {
+    left: 26%;
+  }
+  .header-holder .main-menu ul {
+    padding-left: 0;
+  }
+}
+@media screen and (min-width: 1600px) {
+  .header-holder .main-menu {
+    left: 380px;
+  }
+  .header-holder .main-menu ul {
+    padding-left: 38px;
+  }
 }
 
 .pytorch-page-level-bar {
   display: none;
+  align-items: center;
+  background-color: #ffffff;
+  border-bottom: 1px solid #e2e2e2;
+  top: 90px;
+  width: 100%;
+  z-index: 9999;
 }
-@media screen and (min-width: 1100px) {
+@media screen and (min-width: 1101px) {
   .pytorch-page-level-bar {
-    align-items: center;
-    background-color: #ffffff;
-    border-bottom: 1px solid #e2e2e2;
+    left: 25%;
     display: flex;
-    height: 90px;
-    left: 420px;
-    padding-left: 60px;
     position: fixed;
-    top: 90px;
+    height: 45px;
+    padding-left: 2%;
+    width: 75%;
+  }
+}
+@media screen and (min-width: 1600px) {
+  .pytorch-page-level-bar {
+    left: 420px;
+    height: 90px;
+    padding-left: 60px;
+    right: 0;
     width: 100%;
-    z-index: 9999;
   }
 }
 .pytorch-page-level-bar ul, .pytorch-page-level-bar li {
@@ -10097,7 +10236,16 @@ a[rel~="prev"], a[rel~="next"] {
 .pytorch-shortcuts-wrapper {
   display: none;
   position: absolute;
-  left: 810px;
+}
+@media screen and (min-width: 1101px) {
+  .pytorch-shortcuts-wrapper {
+    left: 78%;
+  }
+}
+@media screen and (min-width: 1600px) {
+  .pytorch-shortcuts-wrapper {
+    left: 820px;
+  }
 }
 
 /*# sourceMappingURL=theme.css.map */

--- a/pytorch_sphinx_theme/static/js/theme.js
+++ b/pytorch_sphinx_theme/static/js/theme.js
@@ -247,20 +247,15 @@ window.scrollToAnchor = {
 
 },{}],6:[function(require,module,exports){
 window.sideMenus = {
-  rightMenuInitialTop: parseInt($(".pytorch-right-menu").css("top"), 10),
+  rightMenuInitialTop: $(".pytorch-article h1:first").offset().top,
 
   bind: function() {
+    // Start the Shortcuts menu at the article's H1 position
+    $(".pytorch-right-menu").css({top: sideMenus.rightMenuInitialTop});
+
     $(window).on('load resize scroll', function(e) {
       sideMenus.handleLeftMenu();
       sideMenus.handleRightMenu();
-    });
-
-    $(window).on("load resize", function() {
-      var leftMenuWidth = $(".pytorch-left-menu").width();
-      var contentRightLeftOffset = $(".pytorch-content-right").offset().left;
-      var pageLevelPaddingLeft = parseInt($(".pytorch-page-level-bar").css("padding-left"), 10);
-      $(".pytorch-right-menu").css({left: contentRightLeftOffset});
-      $(".pytorch-shortcuts-wrapper").css({left: contentRightLeftOffset - leftMenuWidth - pageLevelPaddingLeft});
     });
   },
 
@@ -302,9 +297,9 @@ window.sideMenus = {
     //          of the footer minus padding
 
     if ($rightMenu.hasClass("fixed-to-bottom") && topOfFooterRelativeToWindow >= windowHeight) {
-      $rightMenu.removeClass("fixed-to-bottom").css({top: stoppingPoint, left: ""});
+      $rightMenu.removeClass("fixed-to-bottom").css({top: stoppingPoint});
     } else if (bottom >= -PADDING_BETWEEN_MENU_AND_FOOTER + footerTop) {
-      $rightMenu.addClass("fixed-to-bottom").css({top: "auto", left: 0});
+      $rightMenu.addClass("fixed-to-bottom").css({top: "auto"});
     } else {
       var top = scrollPos >= (initialTop - stoppingPoint)
                   ? stoppingPoint

--- a/scss/_sphinx_base.scss
+++ b/scss/_sphinx_base.scss
@@ -1,3 +1,45 @@
+$sphinx_full_width: 1600px;
+$sphinx_medium_width: 1101px;
+$sphinx_full_width_content_width: 700px;
+
+$sphinx_left_menu_wrapper_padding_right: 15%;
+$sphinx_left_menu_width: 25%;
+$sphinx_left_menu_scroll_wrapper_width: 120%;
+
+$sphinx_content_wrap_width: 71%;
+$sphinx_content_wrap_left_margin: 27%;
+
+$sphinx_article_width: 75%;
+
+$sphinx_right_menu_wrap_width: 24%;
+$sphinx_right_menu_wrap_left_margin: 2%;
+$sphinx_right_menu_width: 17%;
+$sphinx_right_menu_left_margin: 81.5%;
+$sphinx_right_menu_scroll_wrapper_width: 120%;
+
+$sphinx_page_bar_left_margin: 25%;
+$sphinx_page_bar_left_padding: 2%;
+
+$sphinx_shortcuts_left_margin: 78%;
+
+@mixin sphinx-full-size {
+  @media screen and (min-width: $sphinx_full_width) { @content; }
+}
+
+@mixin sphinx-medium-size {
+  @media screen and (min-width: $sphinx_medium_width) { @content; }
+}
+
+html {
+  @include desktop {
+    font-size: 14px;
+  }
+
+  @include sphinx-full-size {
+    font-size: 16px;
+  }
+}
+
 body {
   background: $white;
   height: 100%;

--- a/scss/_sphinx_layout.scss
+++ b/scss/_sphinx_layout.scss
@@ -13,38 +13,56 @@
   position: relative;
   @include clearfix;
 
-  @include full-nav-menu-desktop {
+  @include sphinx-medium-size {
+    left: $sphinx_content_wrap_left_margin;
+    padding-top: 160px;
+    width: $sphinx_content_wrap_width;
+  }
+
+  @include sphinx-full-size {
+    left: auto;
     margin-left: $desktop_menu_width + 60px;
     padding-top: 220px;
+    width: auto;
   }
 }
 
 .pytorch-content {
   background: #ffffff;
   width: 100%;
-  max-width: 675px;
+  max-width: $sphinx_full_width_content_width;
   position: relative;
 }
 
 .pytorch-content-left {
   width: 100%;
-  @include full-nav-menu-desktop {
-    width: 675px;
+
+  @include sphinx-medium-size {
+    width: $sphinx_article_width;
+  }
+
+  @include sphinx-full-size {
+    width: $sphinx_full_width_content_width;
   }
 }
 
 .pytorch-content-right {
   display: none;
-  @include full-nav-menu-desktop {
+  position: relative;
+
+  @include sphinx-medium-size {
     display: block;
+    left: $sphinx_right_menu_wrap_left_margin;
+    width: $sphinx_right_menu_wrap_width;
+  }
+
+  @include sphinx-full-size {
     width: $desktop_menu_width - 70px;
-    position: relative;
-    left: 50px;
+    left: 0;
   }
 }
 
 .pytorch-side-scroll {
-  width: 410px;
   position: relative;
   overflow-x: hidden;
   overflow-y: scroll;
@@ -52,23 +70,16 @@
 }
 
 .pytorch-menu-vertical {
-  padding-bottom: 90px;
-  padding-right: rem(30px);
-}
+  padding: rem(70px) rem(30px) rem(90px) 0;
 
-.pytorch-left-menu-search {
-  margin: rem(40px) 0 rem(60px) 0;
-  padding-left: rem(30px);
-}
+  @include sphinx-medium-size {
+    padding-top: 0;
+    padding-right: $sphinx_left_menu_wrapper_padding_right;
+  }
 
-.pytorch-left-menu-search input[type=text] {
-  border-radius: 0;
-  padding: rem(8px) rem(12px);
-  border-color: $orange;
-  color: $orange;
-  border-style: solid;
-  font-size: rem(16px);
-  width: 100%;
+  @include sphinx-full-size {
+    padding-right: rem(30px);
+  }
 }
 
 .pytorch-left-menu {
@@ -104,15 +115,7 @@
     }
   }
 
-  a.close-table-of-contents {
-    display: block;
-
-    @include full-nav-menu-desktop {
-      display: none;
-    }
-  }
-
-  @include full-nav-menu-desktop {
+  @include sphinx-medium-size {
     background: #f3f4f7;
     bottom: 0;
     color: #252627;
@@ -121,24 +124,74 @@
     overflow-x: hidden;
     overflow-y: hidden;
     padding-bottom: 20px + 90px;
-    padding: 0 rem(60px) 0 rem(30px);
+    padding: 0 rem(30px) 0 0;
     position: fixed;
     top: 90px;
-    width: $desktop_menu_width;
+    min-width: 280px;
+    width: $sphinx_left_menu_width;
     z-index: 200;
   }
 
-  p.caption {
-    color: $not_quite_black;
-    display: block;
-    display: inline-block;
-    font-size: rem(18px);
-    line-height: rem(34px);
-    margin-bottom: rem(16px);
-    padding: 0;
-    text-transform: none;
-    white-space: nowrap;
+  @include sphinx-full-size {
+    padding: 0 rem(60px) 0 rem(30px);
+    width: $desktop_menu_width;
+  }
+}
+
+.pytorch-left-menu p.caption {
+  color: $not_quite_black;
+  display: block;
+  display: inline-block;
+  font-size: rem(18px);
+  line-height: rem(34px);
+  margin-bottom: rem(16px);
+  padding: 0;
+  text-transform: none;
+  white-space: nowrap;
+
+  @include sphinx-medium-size {
     padding-left: rem(30px);
+  }
+}
+
+.pytorch-left-menu a.close-table-of-contents {
+  display: block;
+
+  @include full-nav-menu-desktop {
+    display: none;
+  }
+}
+
+.pytorch-left-menu-search {
+  margin-bottom: rem(40px);
+
+  @include sphinx-medium-size {
+    margin: rem(20px) 0 rem(30px) 0;
+    padding-left: rem(30px);
+  }
+
+  @include sphinx-full-size {
+    margin: rem(40px) 0 rem(60px) 0;
+  }
+}
+
+.pytorch-left-menu-search input[type=text] {
+  border-radius: 0;
+  padding: rem(8px) rem(12px);
+  border-color: $orange;
+  color: $orange;
+  border-style: solid;
+  font-size: rem(16px);
+  width: 100%;
+}
+
+.pytorch-left-menu .pytorch-side-scroll {
+  @include sphinx-medium-size {
+    width: $sphinx_left_menu_scroll_wrapper_width;
+  }
+
+  @include sphinx-full-size {
+    width: 410px;
   }
 }
 
@@ -147,16 +200,26 @@
   overflow-x: hidden;
   overflow-y: hidden;
   position: fixed;
-  top: 315px;
-  width: $desktop_menu_width;
+  top: auto;
   z-index: 200;
   bottom: 0;
+
+  @include sphinx-medium-size {
+    left: $sphinx_right_menu_left_margin;
+    width: $sphinx_right_menu_width;
+  }
+
+  @include sphinx-full-size {
+    left: 1200px;
+    width: 380px;
+  }
 
   &.fixed-to-bottom {
     top: auto;
     bottom: 20px;
     position: absolute;
     left: 0;
+    width: 100%;
   }
 }
 
@@ -335,7 +398,10 @@
 }
 
 .pytorch-left-menu ul {
-  padding-left: rem(30px);
+  padding-left: 0;
+  @include sphinx-medium-size {
+    padding-left: rem(30px);
+  }
 }
 
 .pytorch-right-menu {
@@ -353,20 +419,22 @@
     padding-left: 0;
 
     li {
-      text-indent: 0px;
+      padding-left: 0px;
       li {
-        text-indent: 5px;
-        a {
-          text-indent: 15px;
+        padding-left: 5px;
+        a:link,
+        a:visited,
+        a:hover {
+          padding-left: 5px;
         }
         li {
-          text-indent: 10px;
+          padding-left: 10px;
           li {
-            text-indent: 15px;
+            padding-left: 15px;
             li {
-              text-indent: 20px;
+              padding-left: 20px;
               li {
-                text-indent: 25px;
+                padding-left: 25px;
               }
             }
           }
@@ -381,11 +449,19 @@
 }
 
 .pytorch-right-menu .pytorch-side-scroll {
-  width: $desktop_menu_width + 20px;
+  @include sphinx-medium-size {
+    width: $sphinx_right_menu_scroll_wrapper_width;
+  }
+
+  @include sphinx-full-size {
+    width: $desktop_menu_width + 20px;
+  }
+
   padding-top: 20px;
 
   > ul {
-    padding-left: 25px;
+    padding-left: 10%;
+    padding-right: 10%;
     // Hide the first level (title) of the article
     > li > a {
       display: none;
@@ -404,9 +480,13 @@
         height: 1px;
         display: inline-block;
         position: absolute;
-        left: 5px;
-        top: 13px;
+        left: 0;
+        top: 10px;
         width: 0;
+
+        @include sphinx-full-size {
+          top: 13px;
+        }
       }
 
       li {
@@ -474,7 +554,12 @@
   padding-right: rem(30px);
   padding-left: rem(30px);
 
-  @include full-nav-menu-desktop {
+  @include sphinx-medium-size {
+    padding-right: rem(30px);
+    padding-left: rem(30px);
+  }
+
+  @include sphinx-full-size {
     padding-right: rem(60px);
     padding-left: rem(60px);
   }
@@ -483,24 +568,46 @@
 .header-holder .main-menu {
   justify-content: unset;
   position: relative;
-  left: 380px;
+
+  @include sphinx-medium-size {
+    left: 26%;
+    ul {
+      padding-left: 0;
+    }
+  }
+
+  @include sphinx-full-size {
+    left: 380px;
+    ul {
+      padding-left: 38px;
+    }
+  }
 }
 
 .pytorch-page-level-bar {
   display: none;
+  align-items: center;
+  background-color: $white;
+  border-bottom: 1px solid #e2e2e2;
+  top: 90px;
+  width: 100%;
+  z-index: 9999;
 
-  @include full-nav-menu-desktop {
-    align-items: center;
-    background-color: $white;
-    border-bottom: 1px solid #e2e2e2;
+  @include sphinx-medium-size {
+    left: $sphinx_page_bar_left_margin;
     display: flex;
-    height: $desktop_header_height;
-    left: 420px;
-    padding-left: 60px;
     position: fixed;
-    top: 90px;
+    height: $desktop_header_height / 2;
+    padding-left: $sphinx_page_bar_left_padding;
+    width: 100% - $sphinx_page_bar_left_margin;
+  }
+
+  @include sphinx-full-size {
+    left: 420px;
+    height: $desktop_header_height;
+    padding-left: 60px;
+    right: 0;
     width: 100%;
-    z-index: 9999;
   }
 
   ul, li {
@@ -511,5 +618,12 @@
 .pytorch-shortcuts-wrapper {
   display: none;
   position: absolute;
-  left: 60px + 675px + 50px + 25px;
+
+  @include sphinx-medium-size {
+    left: $sphinx_shortcuts_left_margin;
+  }
+
+  @include sphinx-full-size {
+    left: 820px;
+  }
 }


### PR DESCRIPTION
This PR restructures the page layout on screens from 1100px to 1600px to have percentage based widths for the menus and the content so that more of the content is featured and it resizes appropriately. This screen size also triggers a smaller font size. Basically we want users who are using a typical laptop screen to be able to comfortably navigate the site.

On screen sizes above 1600px it retains the fixed proportions seen in the comps.  