### PR TITLE
[PYT-211] Update article download button display

### DIFF
--- a/pytorch_sphinx_theme/static/css/theme.css
+++ b/pytorch_sphinx_theme/static/css/theme.css
@@ -10580,15 +10580,12 @@ article.pytorch-article .class .attribute dt {
   background-image: url("../images/arrow-down-orange.svg");
   background-color: #f3f4f7;
 }
-.pytorch-article div.sphx-glr-download a:hover span.pre {
-  color: #545454;
-}
 .pytorch-article div.sphx-glr-download a span.pre {
   background-color: transparent;
   font-size: 1.125rem;
   padding: 0;
-  color: #8c8c8c;
-  font-weight: 300;
+  color: #262626;
+  font-weight: 400;
 }
 .pytorch-article div.sphx-glr-download a code, .pytorch-article div.sphx-glr-download a kbd, .pytorch-article div.sphx-glr-download a pre, .pytorch-article div.sphx-glr-download a samp, .pytorch-article div.sphx-glr-download a span.pre {
   font-family: FreightSans, Helvetica Neue, Helvetica, Arial, sans-serif;
@@ -10694,6 +10691,12 @@ article.pytorch-article .math .MathJax_Display {
 }
 .pytorch-breadcrumbs-wrapper .pytorch-breadcrumbs-aside {
   float: right;
+}
+
+.pytorch-article .container {
+  padding-left: 0;
+  padding-right: 0;
+  max-width: none;
 }
 
 .pytorch-container {

--- a/scss/_sphinx_base.scss
+++ b/scss/_sphinx_base.scss
@@ -422,18 +422,14 @@ article.pytorch-article {
       text-decoration: none;
       background-image: url("../images/arrow-down-orange.svg");
       background-color: $light_grey;
-
-      span.pre {
-        color: $content_text_color;
-      }
     }
 
     span.pre {
       background-color: transparent;
       font-size: rem(18px);
       padding: 0;
-      color: $quick_start_grey;
-      font-weight: 300;
+      color: $not_quite_black;
+      font-weight: 400;
     }
 
     code, kbd, pre, samp, span.pre {
@@ -554,4 +550,10 @@ article.pytorch-article {
   .pytorch-breadcrumbs-aside {
     float: right;
   }
+}
+
+.pytorch-article .container {
+  padding-left: 0;
+  padding-right: 0;
+  max-width: none;
 }


### PR DESCRIPTION
The buttons should extend the full width of the article container. Also updates the button text color and weight.

https://shiftlabny.atlassian.net/secure/RapidBoard.jspa?rapidView=21&projectKey=PYT&modal=detail&selectedIssue=PYT-211