### PR TITLE
[PYT-222] Ensure root breadcrumb reflects project

### DIFF
--- a/pytorch_sphinx_theme/breadcrumbs.html
+++ b/pytorch_sphinx_theme/breadcrumbs.html
@@ -28,7 +28,16 @@
 
   <ul class="pytorch-breadcrumbs">
     {% block breadcrumbs %}
-      <li><a href="{{ pathto(master_doc) }}">{{ _('Docs') }}</a> &gt;</li>
+      <li>
+        <a href="{{ pathto(master_doc) }}">
+          {% if theme_pytorch_project == 'tutorials' %}
+            Tutorials
+          {% else %}
+            Docs
+          {% endif %}
+        </a> &gt;
+      </li>
+
         {% for doc in parents %}
           <li><a href="{{ doc.link|e }}">{{ doc.title }}</a> &gt;</li>
         {% endfor %}


### PR DESCRIPTION
Root breadcrumb should be either "Docs" or "Tutorials" depending on the project.