### PR TITLE
[PYT-215] Hide auto-generated ToC in articles

### DIFF
--- a/pytorch_sphinx_theme/static/css/theme.css
+++ b/pytorch_sphinx_theme/static/css/theme.css
@@ -9582,6 +9582,10 @@ a.with-right-arrow, .btn.with-right-arrow {
   }
 }
 
+.pytorch-article #table-of-contents {
+  display: none;
+}
+
 code, kbd, pre, samp {
   font-family: IBMPlexMono,SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace;
 }

--- a/scss/shared/_base_styles.scss
+++ b/scss/shared/_base_styles.scss
@@ -97,3 +97,7 @@ a, .btn {
     }
   }
 }
+
+.pytorch-article #table-of-contents {
+  display: none;
+}


### PR DESCRIPTION
I can only find this in one tutorial at `/beginner/pytorch_with_examples.html`.