### PR TITLE
[PYT-226] Update code block color in right menu

### DIFF
--- a/pytorch_sphinx_theme/layout.html
+++ b/pytorch_sphinx_theme/layout.html
@@ -435,7 +435,7 @@
     })
 
     // Add class to links that have code blocks, since we cannot create links in code blocks
-    $("a span.pre").each(function(e) {
+    $("article.pytorch-article a span.pre").each(function(e) {
       $(this).closest("a").addClass("has-code");
     });
   </script>

--- a/pytorch_sphinx_theme/static/css/theme.css
+++ b/pytorch_sphinx_theme/static/css/theme.css
@@ -11225,7 +11225,15 @@ a:hover {
 .pytorch-right-menu a:hover {
   color: #8c8c8c;
 }
+.pytorch-right-menu a:link span.pre,
+.pytorch-right-menu a:visited span.pre,
+.pytorch-right-menu a:hover span.pre {
+  color: #8c8c8c;
+}
 .pytorch-right-menu li.active > a {
+  color: #ee4c2c;
+}
+.pytorch-right-menu li.active > a span.pre {
   color: #ee4c2c;
 }
 .pytorch-right-menu li.active > a:before {

--- a/scss/_sphinx_layout.scss
+++ b/scss/_sphinx_layout.scss
@@ -405,10 +405,18 @@
   a:visited,
   a:hover {
     color: $quick_start_grey;
+
+    span.pre {
+      color: $quick_start_grey;
+    }
   }
 
   li.active > a {
     color: $red_orange;
+
+    span.pre {
+      color: $red_orange;
+    }
 
     &:before {
       content: "\2022";


### PR DESCRIPTION
They should be the same grey as the other links, not blue, and should turn orange when active like the other links.