### PR TITLE
[PYT-256] Update right menu styling as per Airlift specs

### DIFF
--- a/js/side-menus.js
+++ b/js/side-menus.js
@@ -13,6 +13,13 @@ window.sideMenus = {
       // Don't show the Shortcuts menu title text unless there are menu items
       document.getElementById("pytorch-shortcuts-wrapper").style.display = "block";
 
+      // Remove superfluous titles unless there are more than one
+      var titles = document.querySelectorAll("#pytorch-side-scroll-right > ul > li");
+
+      if (titles.length === 1) {
+        titles[0].querySelector("a.reference.internal").style.display = "none";
+      }
+
       // Start the Shortcuts menu at the article's H1 position
       document.getElementById("pytorch-right-menu").style["margin-top"] = sideMenus.rightMenuInitialTop() + "px";
 

--- a/pytorch_sphinx_theme/static/css/theme.css
+++ b/pytorch_sphinx_theme/static/css/theme.css
@@ -11233,20 +11233,20 @@ a:hover {
 .pytorch-right-menu li.active > a {
   color: #ee4c2c;
 }
-.pytorch-right-menu li.active > a span.pre {
+.pytorch-right-menu li.active > a span.pre, .pytorch-right-menu li.active > a:before {
   color: #ee4c2c;
 }
-.pytorch-right-menu li.active > a:before {
+.pytorch-right-menu li.active > a:after {
   content: "\2022";
   color: #e44c2c;
   display: inline-block;
   font-size: 1.375rem;
-  left: -15px;
+  left: -17px;
   position: absolute;
   top: 1px;
 }
 .pytorch-right-menu .pytorch-side-scroll > ul > li > ul > li {
-  margin-bottom: 0.625rem;
+  margin-bottom: 1.375rem;
 }
 .pytorch-right-menu ul ul {
   padding-left: 0;
@@ -11255,25 +11255,25 @@ a:hover {
   padding-left: 0px;
 }
 .pytorch-right-menu ul ul li a.reference.internal {
-  padding-left: 10px;
+  padding-left: 0;
 }
 .pytorch-right-menu ul ul li li a.reference.internal {
-  padding-left: 15px;
+  padding-left: 0;
+}
+.pytorch-right-menu ul ul li li a.reference.internal:before {
+  content: "\2014";
 }
 .pytorch-right-menu ul ul li li li a.reference.internal {
-  padding-left: 20px;
+  padding-left: 15px;
 }
 .pytorch-right-menu ul ul li li li li a.reference.internal {
-  padding-left: 25px;
+  padding-left: 20px;
 }
 .pytorch-right-menu ul ul li li li li li a.reference.internal {
-  padding-left: 30px;
-}
-.pytorch-right-menu ul ul li li li li li a.reference.internal.active a:before {
-  left: -40px;
+  padding-left: 25px;
 }
 .pytorch-right-menu ul ul li li li li li li a.reference.internal {
-  padding-left: 35px;
+  padding-left: 30px;
 }
 .pytorch-right-menu li ul {
   display: block;
@@ -11297,41 +11297,11 @@ a:hover {
   padding-right: 10%;
   margin-bottom: 0;
 }
+.pytorch-right-menu .pytorch-side-scroll > ul > li > a.reference.internal {
+  color: #252627;
+}
 .pytorch-right-menu .pytorch-side-scroll ul li {
   position: relative;
-}
-.pytorch-right-menu .pytorch-side-scroll ul ul li:before {
-  content: "";
-  background-color: #8c8c8c;
-  height: 1px;
-  display: inline-block;
-  position: absolute;
-  left: 0;
-  top: 10px;
-  width: 5px;
-}
-@media screen and (min-width: 1600px) {
-  .pytorch-right-menu .pytorch-side-scroll ul ul li:before {
-    top: 13px;
-  }
-}
-.pytorch-right-menu .pytorch-side-scroll ul ul li li:before {
-  width: 10px;
-}
-.pytorch-right-menu .pytorch-side-scroll ul ul li li li:before {
-  width: 15px;
-}
-.pytorch-right-menu .pytorch-side-scroll ul ul li li li li:before {
-  width: 20px;
-}
-.pytorch-right-menu .pytorch-side-scroll ul ul li li li li li:before {
-  width: 25px;
-}
-.pytorch-right-menu .pytorch-side-scroll ul ul li li li li li li:before {
-  width: 30px;
-}
-.pytorch-right-menu .pytorch-side-scroll ul ul li.active:before {
-  background-color: #ee4c2c;
 }
 
 .header-container {

--- a/pytorch_sphinx_theme/static/js/theme.js
+++ b/pytorch_sphinx_theme/static/js/theme.js
@@ -371,6 +371,13 @@ window.sideMenus = {
       // Don't show the Shortcuts menu title text unless there are menu items
       document.getElementById("pytorch-shortcuts-wrapper").style.display = "block";
 
+      // Remove superfluous titles unless there are more than one
+      var titles = document.querySelectorAll("#pytorch-side-scroll-right > ul > li");
+
+      if (titles.length === 1) {
+        titles[0].querySelector("a.reference.internal").style.display = "none";
+      }
+
       // Start the Shortcuts menu at the article's H1 position
       document.getElementById("pytorch-right-menu").style["margin-top"] = sideMenus.rightMenuInitialTop() + "px";
 

--- a/scss/_sphinx_layout.scss
+++ b/scss/_sphinx_layout.scss
@@ -414,23 +414,24 @@
   li.active > a {
     color: $red_orange;
 
-    span.pre {
+    span.pre,
+    &:before {
       color: $red_orange;
     }
 
-    &:before {
+    &:after {
       content: "\2022";
       color: $orange;
       display: inline-block;
       font-size: rem(22px);
-      left: -15px;
+      left: -17px;
       position: absolute;
       top: 1px;
     }
   }
 
   .pytorch-side-scroll > ul > li > ul > li {
-    margin-bottom: rem(10px);
+    margin-bottom: rem(22px);
   }
 
   ul ul {
@@ -440,36 +441,36 @@
       padding-left: 0px;
 
       a.reference.internal {
-        padding-left: 10px;
+        padding-left: 0;
       }
 
       li {
           a.reference.internal {
-            padding-left: 15px;
+            padding-left: 0;
+
+            &:before {
+              content: "\2014";
+            }
           }
 
         li {
           a.reference.internal {
-            padding-left: 20px;
+            padding-left: 15px;
           }
 
           li {
             a.reference.internal {
-              padding-left: 25px;
+              padding-left: 20px;
             }
 
             li {
               a.reference.internal {
-                padding-left: 30px;
-
-                &.active a:before {
-                  left: -40px;
-                }
+                padding-left: 25px;
               }
 
               li {
                 a.reference.internal {
-                  padding-left: 35px;
+                  padding-left: 30px;
                 }
               }
             }
@@ -499,61 +500,13 @@
     padding-left: 10%;
     padding-right: 10%;
     margin-bottom: 0;
+    > li > a.reference.internal {
+      color: $slate;
+    }
   }
 
   ul li {
     position: relative;
-  }
-
-  ul ul {
-    li {
-      &:before {
-        content: "";
-        background-color: $quick_start_grey;
-        height: 1px;
-        display: inline-block;
-        position: absolute;
-        left: 0;
-        top: 10px;
-        width: 5px;
-
-        @include sphinx-full-size {
-          top: 13px;
-        }
-      }
-
-      li {
-        &:before {
-          width: 10px;
-        }
-        li {
-          &:before {
-            width: 15px;
-          }
-          li {
-            &:before {
-              width: 20px;
-            }
-            li {
-              &:before {
-                width: 25px;
-              }
-              li {
-                &:before {
-                  width: 30px;
-                }
-              }
-            }
-          }
-        }
-      }
-
-      &.active {
-        &:before {
-          background-color: $red_orange;
-        }
-      }
-    }
   }
 }
 


### PR DESCRIPTION
- Increase margin bottom between sections
- Update left margins of menu items and sub menu items
- Don't show the top level menu items unless there are multiple top level menu items (torch.nn)
- If there are multiple top level items, display the items in dark grey text

Check out ethelind's comments in the slack channel to compare. She also mentioned increasing the bottom padding but that'll have to wait for a separate PR.