### PR TITLE
Update MathJax minScaleAdjust

### DIFF
--- a/js/mathjax.js
+++ b/js/mathjax.js
@@ -5,7 +5,9 @@ MathJax.Hub.Config({
         showMathMenu: false,
         linebreaks: { automatic: true, width: "container" } ,
         preferredFont: "STIX",
-        availableFonts: ["STIX","TeX"]
+        availableFonts: ["STIX","TeX"],
+        scale: 100,
+        minScaleAdjust: 100
     },
     SVG: { linebreaks: { automatic: true, width: "container" } }
  });


### PR DESCRIPTION
duplicating the efforts done by @brsoff on the new theme. I can only find one of the changes possible, since there is nothing like .MathJax_Display as shown below

```
article.pytorch-article {
  .math {
    color: $not_quite_black;
    width: auto;
    text-align: center;
    img {
      width: auto;
    }
  }
}
```